### PR TITLE
Fix image_builder for arm64

### DIFF
--- a/image_builder
+++ b/image_builder
@@ -4,7 +4,7 @@ function get_arch()
 {
     local architecture
     if uname -m | grep -q "arm64" || uname -m | grep -q "aarch64"; then
-        architecture="aarch64"
+        architecture="arm64"
     elif uname -m | grep -q "64"; then
         architecture="amd64"
     elif uname -m | grep -q "86"; then


### PR DESCRIPTION
At https://us.lxd.images.canonical.com/; there is no aarch64 architecture, only arm64